### PR TITLE
fix(cpal): handle multi-channel output correctly to prevent speed/pitch-up

### DIFF
--- a/src/backend/cpal.rs
+++ b/src/backend/cpal.rs
@@ -2,7 +2,8 @@ use crate::Backend;
 use anyhow::{anyhow, Context, Result};
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    BufferSize, OutputCallbackInfo, Stream, StreamError,
+    BufferSize, FromSample, I24, OutputCallbackInfo, Sample, SampleFormat, Stream, StreamError,
+    U24,
 };
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -34,6 +35,71 @@ impl CpalBackend {
     }
 }
 
+fn write_output<T: Sample + FromSample<f32>>(
+    state: &Arc<StateCell>,
+    channels: usize,
+    data: &mut [T],
+    info: &OutputCallbackInfo,
+    stereo_scratch: &mut Vec<f32>,
+    out_scratch: &mut Vec<f32>,
+) {
+    let channels = channels.max(1);
+    let frame_count = data.len() / channels;
+    let (mixer, rec) = state.get();
+
+    let rendered: &[f32] = if channels == 1 {
+        out_scratch.resize(frame_count, 0.0);
+        mixer.render_mono(out_scratch);
+        out_scratch.as_slice()
+    } else if channels == 2 {
+        stereo_scratch.resize(frame_count * 2, 0.0);
+        mixer.render_stereo(stereo_scratch);
+        stereo_scratch.as_slice()
+    } else {
+        // Render as stereo first, then expand per frame.
+        // This keeps time progression tied to frame count, not channel count.
+        stereo_scratch.resize(frame_count * 2, 0.0);
+        mixer.render_stereo(stereo_scratch);
+
+        out_scratch.resize(frame_count * channels, 0.0);
+        for (stereo, frame) in stereo_scratch
+            .chunks_exact(2)
+            .zip(out_scratch.chunks_exact_mut(channels))
+        {
+            let left = stereo[0];
+            let right = stereo[1];
+            frame[0] = left;
+            frame[1] = right;
+            let surround = (left + right) * 0.5;
+            for sample in &mut frame[2..] {
+                *sample = surround;
+            }
+        }
+        out_scratch.as_slice()
+    };
+
+    for sample in data.iter_mut() {
+        *sample = T::from_sample(0.0);
+    }
+    for (dst, src) in data.iter_mut().zip(rendered.iter().copied()) {
+        *dst = T::from_sample(src);
+    }
+
+    let ts = info.timestamp();
+    if let Some(delay) = ts.playback.duration_since(&ts.callback) {
+        rec.push(delay.as_secs_f32());
+    }
+}
+
+fn make_error_callback(broken: Arc<AtomicBool>) -> impl FnMut(StreamError) + Send + 'static {
+    move |err| {
+        eprintln!("audio error: {err:?}");
+        if matches!(err, StreamError::DeviceNotAvailable) {
+            broken.store(true, Ordering::Relaxed);
+        }
+    }
+}
+
 impl Backend for CpalBackend {
     fn setup(&mut self, setup: BackendSetup) -> Result<()> {
         self.state = Some(Arc::new(setup.into()));
@@ -45,54 +111,60 @@ impl Backend for CpalBackend {
         let device = host
             .default_output_device()
             .ok_or_else(|| anyhow!("no default output device is found"))?;
-        let mut config = device
+        let default_config = device
             .default_output_config()
-            .context("cannot get output config")?
-            .config();
+            .context("cannot get output config")?;
+        let sample_format = default_config.sample_format();
+        let mut config = default_config.config();
         config.buffer_size = self
             .settings
             .buffer_size
             .map_or(BufferSize::Default, BufferSize::Fixed);
+        let channels = config.channels.max(1) as usize;
 
-        let broken = Arc::clone(&self.broken);
-        let error_callback = move |err| {
-            eprintln!("audio error: {err:?}");
-            if matches!(err, StreamError::DeviceNotAvailable) {
-                broken.store(true, Ordering::Relaxed);
-            }
-        };
         let state = Arc::clone(self.state.as_ref().unwrap());
         state.get().0.sample_rate = config.sample_rate;
-        let stream = (if config.channels == 1 {
-            device.build_output_stream(
-                &config,
-                move |data: &mut [f32], info: &OutputCallbackInfo| {
-                    let (mixer, rec) = state.get();
-                    mixer.render_mono(data);
-                    let ts = info.timestamp();
-                    if let Some(delay) = ts.playback.duration_since(&ts.callback) {
-                        rec.push(delay.as_secs_f32());
-                    }
-                },
-                error_callback,
-                None,
-            )
-        } else {
-            device.build_output_stream(
-                &config,
-                move |data: &mut [f32], info: &OutputCallbackInfo| {
-                    let (mixer, rec) = state.get();
-                    mixer.render_stereo(data);
-                    let ts = info.timestamp();
-                    if let Some(delay) = ts.playback.duration_since(&ts.callback) {
-                        rec.push(delay.as_secs_f32());
-                    }
-                },
-                error_callback,
-                None,
-            )
-        })
+
+        macro_rules! build_stream {
+            ($sample_ty:ty) => {{
+                let state = Arc::clone(&state);
+                let mut stereo_scratch = Vec::<f32>::new();
+                let mut out_scratch = Vec::<f32>::new();
+                device.build_output_stream(
+                    &config,
+                    move |data: &mut [$sample_ty], info: &OutputCallbackInfo| {
+                        write_output(
+                            &state,
+                            channels,
+                            data,
+                            info,
+                            &mut stereo_scratch,
+                            &mut out_scratch,
+                        );
+                    },
+                    make_error_callback(Arc::clone(&self.broken)),
+                    None,
+                )
+            }};
+        }
+
+        let stream = match sample_format {
+            SampleFormat::I8 => build_stream!(i8),
+            SampleFormat::I16 => build_stream!(i16),
+            SampleFormat::I24 => build_stream!(I24),
+            SampleFormat::I32 => build_stream!(i32),
+            SampleFormat::I64 => build_stream!(i64),
+            SampleFormat::U8 => build_stream!(u8),
+            SampleFormat::U16 => build_stream!(u16),
+            SampleFormat::U24 => build_stream!(U24),
+            SampleFormat::U32 => build_stream!(u32),
+            SampleFormat::U64 => build_stream!(u64),
+            SampleFormat::F32 => build_stream!(f32),
+            SampleFormat::F64 => build_stream!(f64),
+            _ => Err(cpal::BuildStreamError::StreamConfigNotSupported),
+        }
         .context("failed to build stream")?;
+
         stream.play()?;
         self.stream = Some(stream);
         Ok(())

--- a/src/backend/cpal.rs
+++ b/src/backend/cpal.rs
@@ -2,7 +2,7 @@ use crate::Backend;
 use anyhow::{anyhow, Context, Result};
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    BufferSize, FromSample, I24, OutputCallbackInfo, Sample, SampleFormat, Stream, StreamError,
+    BufferSize, FromSample, OutputCallbackInfo, Sample, SampleFormat, Stream, StreamError, I24,
     U24,
 };
 use std::sync::{
@@ -36,7 +36,7 @@ impl CpalBackend {
 }
 
 fn write_output<T: Sample + FromSample<f32>>(
-    state: &Arc<StateCell>,
+    state: &StateCell,
     channels: usize,
     data: &mut [T],
     info: &OutputCallbackInfo,
@@ -45,6 +45,8 @@ fn write_output<T: Sample + FromSample<f32>>(
 ) {
     let channels = channels.max(1);
     let frame_count = data.len() / channels;
+    let sample_count = frame_count * channels;
+    let (data, tail) = data.split_at_mut(sample_count);
     let (mixer, rec) = state.get();
 
     let rendered: &[f32] = if channels == 1 {
@@ -52,9 +54,9 @@ fn write_output<T: Sample + FromSample<f32>>(
         mixer.render_mono(out_scratch);
         out_scratch.as_slice()
     } else if channels == 2 {
-        stereo_scratch.resize(frame_count * 2, 0.0);
-        mixer.render_stereo(stereo_scratch);
-        stereo_scratch.as_slice()
+        out_scratch.resize(frame_count * 2, 0.0);
+        mixer.render_stereo(out_scratch);
+        out_scratch.as_slice()
     } else {
         // Render as stereo first, then expand per frame.
         // This keeps time progression tied to frame count, not channel count.
@@ -71,19 +73,60 @@ fn write_output<T: Sample + FromSample<f32>>(
             frame[0] = left;
             frame[1] = right;
             let surround = (left + right) * 0.5;
-            for sample in &mut frame[2..] {
-                *sample = surround;
-            }
+            frame[2..].fill(surround);
         }
         out_scratch.as_slice()
     };
 
-    for sample in data.iter_mut() {
-        *sample = T::from_sample(0.0);
-    }
     for (dst, src) in data.iter_mut().zip(rendered.iter().copied()) {
         *dst = T::from_sample(src);
     }
+    for sample in tail {
+        *sample = T::from_sample(0.0);
+    }
+
+    let ts = info.timestamp();
+    if let Some(delay) = ts.playback.duration_since(&ts.callback) {
+        rec.push(delay.as_secs_f32());
+    }
+}
+
+fn write_output_f32(
+    state: &StateCell,
+    channels: usize,
+    data: &mut [f32],
+    info: &OutputCallbackInfo,
+    stereo_scratch: &mut Vec<f32>,
+) {
+    let channels = channels.max(1);
+    let frame_count = data.len() / channels;
+    let sample_count = frame_count * channels;
+    let (data, tail) = data.split_at_mut(sample_count);
+    let (mixer, rec) = state.get();
+
+    if channels == 1 {
+        mixer.render_mono(data);
+    } else if channels == 2 {
+        mixer.render_stereo(data);
+    } else {
+        // Render as stereo first, then expand per frame.
+        // This keeps time progression tied to frame count, not channel count.
+        stereo_scratch.resize(frame_count * 2, 0.0);
+        mixer.render_stereo(stereo_scratch);
+
+        for (stereo, frame) in stereo_scratch
+            .chunks_exact(2)
+            .zip(data.chunks_exact_mut(channels))
+        {
+            let left = stereo[0];
+            let right = stereo[1];
+            frame[0] = left;
+            frame[1] = right;
+            let surround = (left + right) * 0.5;
+            frame[2..].fill(surround);
+        }
+    }
+    tail.fill(0.0);
 
     let ts = info.timestamp();
     if let Some(delay) = ts.playback.duration_since(&ts.callback) {
@@ -134,13 +177,27 @@ impl Backend for CpalBackend {
                     &config,
                     move |data: &mut [$sample_ty], info: &OutputCallbackInfo| {
                         write_output(
-                            &state,
+                            state.as_ref(),
                             channels,
                             data,
                             info,
                             &mut stereo_scratch,
                             &mut out_scratch,
                         );
+                    },
+                    make_error_callback(Arc::clone(&self.broken)),
+                    None,
+                )
+            }};
+        }
+        macro_rules! build_stream_f32 {
+            () => {{
+                let state = Arc::clone(&state);
+                let mut stereo_scratch = Vec::<f32>::new();
+                device.build_output_stream(
+                    &config,
+                    move |data: &mut [f32], info: &OutputCallbackInfo| {
+                        write_output_f32(state.as_ref(), channels, data, info, &mut stereo_scratch);
                     },
                     make_error_callback(Arc::clone(&self.broken)),
                     None,
@@ -159,7 +216,7 @@ impl Backend for CpalBackend {
             SampleFormat::U24 => build_stream!(U24),
             SampleFormat::U32 => build_stream!(u32),
             SampleFormat::U64 => build_stream!(u64),
-            SampleFormat::F32 => build_stream!(f32),
+            SampleFormat::F32 => build_stream_f32!(),
             SampleFormat::F64 => build_stream!(f64),
             _ => Err(cpal::BuildStreamError::StreamConfigNotSupported),
         }

--- a/src/backend/cpal.rs
+++ b/src/backend/cpal.rs
@@ -72,8 +72,7 @@ fn write_output<T: Sample + FromSample<f32>>(
             let right = stereo[1];
             frame[0] = left;
             frame[1] = right;
-            let surround = (left + right) * 0.5;
-            frame[2..].fill(surround);
+            frame[2..].fill(0.0);
         }
         out_scratch.as_slice()
     };
@@ -122,8 +121,7 @@ fn write_output_f32(
             let right = stereo[1];
             frame[0] = left;
             frame[1] = right;
-            let surround = (left + right) * 0.5;
-            frame[2..].fill(surround);
+            frame[2..].fill(0.0);
         }
     }
     tail.fill(0.0);


### PR DESCRIPTION
## Summary

This PR fixes incorrect playback speed and pitch when the output device has more than 2 channels (e.g. 5.1 / 7.1 on Windows) in the CPAL backend.

## Root Cause

In `src/backend/cpal.rs`, the callback path treated all `channels != 1` as stereo and rendered directly into the raw callback buffer.
For devices with `channels > 2`, this made the renderer advance playback by callback-sample count instead of frame count, causing accelerated playback and higher pitch.

## Changes

- Updated CPAL stream creation to dispatch by actual `SampleFormat` (`i8/i16/i24/.../f64`).
- Added channel-aware output rendering logic.
- For `channels == 1`, render mono by frame count.
- For `channels == 2`, render stereo by frame count.
- For `channels > 2`, render to stereo scratch buffer first, then expand per-frame to N-channel output.
- Kept existing latency recording and device error handling behavior.

## Reproduction

1. Use a machine with default output device configured to 5.1/7.1 channels.
2. Play an OGG/MP3 track.
3. Observe playback is faster and pitch is higher than expected.

## Verification

- `cargo check` passes.
- Manual playback test on stereo output: normal speed/pitch.
- Manual playback test on multichannel output: normal speed/pitch after fix.

## Compatibility / Risk

- No API changes.
- No behavior change expected for mono/stereo devices.
- Multichannel behavior is corrected to frame-based progression.

## Checklist

- [x] Fix is scoped to CPAL backend.
- [x] No public API changes.
- [x] Build passes locally.
- [x] Manual regression checked on stereo output.
- [x] Manual verification done for multichannel output.